### PR TITLE
Make compatible with older versions of GCC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     ext_modules=[
         Extension(
             name="_robustats",
-            sources=["c/_robustats.c", "c/robustats.c", "c/base.c"]
+            sources=["c/_robustats.c", "c/robustats.c", "c/base.c"],
+            extra_compile_args=["-std=c99"]
         )
     ],
     include_dirs=numpy.distutils.misc_util.get_numpy_include_dirs(),


### PR DESCRIPTION
Hello, and thanks for your work on this package. I ran into an issue installing this package on a server that uses an older version of GCC (4.8.5) and couldn't compile due to for loop initialization. This change adds the compilation option that allows for older versions of GCC to compile robustats c files. 