### PR TITLE
fix for Install failed with Python 3.7.7 on Windows

### DIFF
--- a/c/base.c
+++ b/c/base.c
@@ -13,7 +13,7 @@
  * Returns:
  *    Higher of the two numbers.
  */
-double max(double a, double b)
+double max_(double a, double b)
 {
    return a >= b ? a : b;
 }

--- a/c/base.h
+++ b/c/base.h
@@ -1,6 +1,6 @@
 #include <stdint.h>
 
-double max(double a, double b);
+double max_(double a, double b);
 double sign(double x);
 int64_t sum_int(int64_t *x, int64_t n);
 double sum_double(double *x, int64_t n);

--- a/c/robustats.c
+++ b/c/robustats.c
@@ -191,7 +191,7 @@ double medcouple(double *x, int64_t n, double epsilon1, double epsilon2)
 
    // To rescale z_minus and z_plus inside [-0.5, 0.5], for greater numerical
    // stability.
-   double scale_factor = 2 * max(x[0] - median, median - x[n - 1]);
+   double scale_factor = 2 * max_(x[0] - median, median - x[n - 1]);
 
    // Create z_plus
    int64_t lowest_median_index = median_index;


### PR DESCRIPTION
fixed name clash for function "max" under Windows. compiled successfully, tests passed. kindly review.